### PR TITLE
refactor: adiciona width e height explícitos à imagem de retrato

### DIFF
--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,5 +1,5 @@
 
-import { About, Description, Portrait, SocialMedia, Curriculo } from './styles';
+import { About, Description, Portrait, Image, SocialMedia, Curriculo } from './styles';
 import { Instagram, LinkedIn, GitHub, FileDownload } from '@mui/icons-material';
 import Skills from '../../components/skills';
 import Thumbnail from '../../components/thumbnails';
@@ -23,13 +23,7 @@ const Home = () => {
                     </SocialMedia>
                 </Description>
                 <Portrait>
-                    <Thumbnail
-                        key='1'
-                        url={portraitImg}
-                        alt='Marcos Tavares'
-                        height={320}
-                        width={320}
-                    />
+                    <Image src={portraitImg} width={260} height={260} className='photo' />
                 </Portrait>
             </About>
 

--- a/src/pages/home/styles.ts
+++ b/src/pages/home/styles.ts
@@ -91,13 +91,16 @@ export const Portrait = styled.div`
     background-size: contain;
     width: 50%;
     display: flex;
+    align-items: center;
+    justify-content: end;
     @media (max-width: 576px) {
         width: 100%;
         display: none;
     }
 `;
-export const Image = styled.div`
-
+export const Image = styled.img`
+    border-radius: 100%;
+    border: 3px solid #09f0b4;
 `;
 export const Skills = styled.section`
 

--- a/src/pages/home/styles.ts
+++ b/src/pages/home/styles.ts
@@ -100,7 +100,7 @@ export const Portrait = styled.div`
 `;
 export const Image = styled.img`
     border-radius: 100%;
-    border: 3px solid #09f0b4;
+    border: 3px solid #09f0b4; 
 `;
 export const Skills = styled.section`
 


### PR DESCRIPTION
### Descrição

Esta alteração define explicitamente as propriedades `width` e `height` para a imagem de retrato (`<Image />`), melhorando o desempenho e evitando o layout shift.

### Alterações realizadas

- Atualizado o componente `<Image />` para incluir os atributos:
  - `width={260}`
  - `height={260}`

### Antes

```jsx
<Image src={portraitImg} className='photo' />
