### PR TITLE
Adicionar dados de SEO (Yoast) no PostType

### DIFF
--- a/src/pages/blog/single/PostContent.tsx
+++ b/src/pages/blog/single/PostContent.tsx
@@ -69,6 +69,8 @@ const SinglePost = () => {
                 </Content>
             </EntryContent>
 
+            {/* {console.log(post?.yoast_head_json)} */}
+
             <title>{`Blog - ${post?.title}`}</title>
 
             <meta name="description" content="Marcos Tavares, desenvolvedor full stack especializado em JavaScript. 

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -54,6 +54,19 @@ export interface AuthorData {
   avatar_urls?: AvatarUrls;
 }
 
+export interface Seo {
+  title?: string;
+  description?: string;
+  keywords?: string[];
+  og_locale?: string;
+  og_image?: string;
+  og_type?: string;
+  og_site_name?: string;
+  og_url?: string;
+  article_published_time?: string;
+  article_modified_time?: string;
+}
+
 export interface PostType {
   id: number;
   title: string;
@@ -64,6 +77,7 @@ export interface PostType {
   categories_details?: Category[];
   author_data?: AuthorData;
   slug?: string;
+  yoast_head_json?: Seo[]
 }
 
 export interface EntryMetaContent {


### PR DESCRIPTION
**Objetivo**

Adicionar os dados de SEO do Yoast (yoast_head_json) na resposta da API para os posts, de forma que o frontend possa consumir e tipar corretamente via TypeScript (Seo[]).

**Motivação**

O frontend agora pode consumir todos os dados de SEO do Yoast diretamente, sem precisar parsear HTML ou JSON bruto, permitindo tipagem segura e integração com a interface Seo[].